### PR TITLE
五七五を管理するSenryuのベースとなる一覧、投稿、削除機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,9 @@ gem 'bootsnap', '>= 1.1.0', require: false
 
 group :development, :test do  
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry-rails'
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -1,62 +1,41 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
+# Core
 ruby '2.6.3'
-
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'
-# Use postgresql as the database for Active Record
+
+# Middle
 gem 'pg', '>= 0.18', '< 2.0'
-# Use Puma as the app server
 gem 'puma', '~> 3.11'
-# Use SCSS for stylesheets
+
+# Asset
 gem 'sass-rails', '~> 5.0'
-# Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
-# See https://github.com/rails/execjs#readme for more supported runtimes
-# gem 'mini_racer', platforms: :ruby
-
-# Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
-# Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
+
 gem 'turbolinks', '~> 5'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
+
 gem 'jbuilder', '~> 2.5'
-# Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 4.0'
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
 
-# Use ActiveStorage variant
-# gem 'mini_magick', '~> 4.8'
-
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
-
-# Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
-group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+group :development, :test do  
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end
 
 group :development do
-  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
 group :test do
-  # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
-  # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'chromedriver-helper'
 end
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,13 @@ GEM
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
+    better_errors (2.5.1)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
     bindex (0.7.0)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.4.4)
       msgpack (~> 1.0)
     builder (3.2.3)
@@ -65,6 +71,7 @@ GEM
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -74,6 +81,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
+    debug_inspector (0.0.3)
     erubi (1.8.0)
     execjs (2.7.0)
     ffi (1.11.1)
@@ -105,6 +113,11 @@ GEM
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     pg (1.1.4)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (3.1.0)
     puma (3.12.1)
     rack (2.0.7)
@@ -192,6 +205,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  better_errors
+  binding_of_caller
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15)
@@ -200,6 +215,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
+  pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)
   sass-rails (~> 5.0)

--- a/app/controllers/senryus_controller.rb
+++ b/app/controllers/senryus_controller.rb
@@ -17,11 +17,18 @@ class SenryusController < ApplicationController
   end
 
   def destroy
+    set_senryu
+    @senryu.destroy
+    redirect_to senryus_url, notice: "deleted successfully"
   end
 
   private
 
   def senryu_params
     params.require(:senryu).permit(:content)
+  end
+
+  def set_senryu
+    @senryu = Senryu.find(params[:id])
   end
 end

--- a/app/controllers/senryus_controller.rb
+++ b/app/controllers/senryus_controller.rb
@@ -1,7 +1,27 @@
 class SenryusController < ApplicationController
   def index
+    @senryus = Senryu.all
   end
 
   def new
+    @senryu = Senryu.new
+  end
+
+  def create
+    @senryu = Senryu.new(senryu_params)
+    if @senryu.save
+      redirect_to senryus_url, notice: "posted successfully"
+    else
+      render 'new'
+    end
+  end
+
+  def destroy
+  end
+
+  private
+
+  def senryu_params
+    params.require(:senryu).permit(:content)
   end
 end

--- a/app/controllers/senryus_controller.rb
+++ b/app/controllers/senryus_controller.rb
@@ -1,0 +1,7 @@
+class SenryusController < ApplicationController
+  def index
+  end
+
+  def new
+  end
+end

--- a/app/models/senryu.rb
+++ b/app/models/senryu.rb
@@ -1,0 +1,2 @@
+class Senryu < ApplicationRecord
+end

--- a/app/views/senryus/index.html.erb
+++ b/app/views/senryus/index.html.erb
@@ -3,7 +3,10 @@
 
 <ul>
   <% @senryus.each do |senryu| %>
-    <li><%= senryu.content %></li>
+    <li>
+      <%= senryu.content %>
+      <%= link_to '<delete>', senryu_path(senryu.id), method: :delete %>
+    </li>
   <% end %>
 </ul>
 

--- a/app/views/senryus/index.html.erb
+++ b/app/views/senryus/index.html.erb
@@ -1,2 +1,9 @@
-<h1>Senryus#index</h1>
-<p>Find me in app/views/senryus/index.html.erb</p>
+<h1>Senryu#index</h1>
+
+
+<ul>
+  <% @senryus.each do |senryu| %>
+    <li><%= senryu.content %></li>
+  <% end %>
+</ul>
+

--- a/app/views/senryus/index.html.erb
+++ b/app/views/senryus/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Senryus#index</h1>
+<p>Find me in app/views/senryus/index.html.erb</p>

--- a/app/views/senryus/new.html.erb
+++ b/app/views/senryus/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Senryus#new</h1>
+<p>Find me in app/views/senryus/new.html.erb</p>

--- a/app/views/senryus/new.html.erb
+++ b/app/views/senryus/new.html.erb
@@ -1,2 +1,24 @@
 <h1>Senryus#new</h1>
-<p>Find me in app/views/senryus/new.html.erb</p>
+
+<%= form_with(model: @senryu, local: true) do |form| %>
+  <% if @senryu.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@senryu.errors.count, "error") %> prohibited this @senryu from being saved:</h2>
+
+      <ul>
+      <% @senryu.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :content %>
+    <%= form.text_field :content %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,5 +10,10 @@ module Yoin
     config.active_record.default_timezone = :local
 
     config.load_defaults 5.2
+
+    config.generators do |g|
+      g.assets false
+      g.helper false
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,18 +2,13 @@ require_relative 'boot'
 
 require 'rails/all'
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module Yoin
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
 
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
+    config.load_defaults 5.2
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  resources :senryus, only: %w(index new create destroy)
 end

--- a/db/migrate/20190611031419_create_senryus.rb
+++ b/db/migrate/20190611031419_create_senryus.rb
@@ -1,0 +1,9 @@
+class CreateSenryus < ActiveRecord::Migration[5.2]
+  def change
+    create_table :senryus do |t|
+      t.string :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2019_06_11_031419) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "senryus", force: :cascade do |t|
+    t.string "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/test/controllers/senryus_controller_test.rb
+++ b/test/controllers/senryus_controller_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class SenryusControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get senryus_index_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get senryus_new_url
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/senryus.yml
+++ b/test/fixtures/senryus.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  content: MyString
+
+two:
+  content: MyString

--- a/test/models/senryu_test.rb
+++ b/test/models/senryu_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SenryuTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
差し当たり、本アプリのテーマである五七五投稿のベースとなる機能を実装
* 全投稿の一覧表示機能(※ユーザー概念の未導入により、単純な投稿一覧表示)
* 川柳用の投稿機能(※五七五の文字数制限や、バリデーション、投稿ページの体裁 etc. は未実装)
* 削除機能