### PR TITLE
Userモデルに設定したバリデーション全てを網羅して保証するSpecを追加

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,20 +4,55 @@ RSpec.describe User, type: :model do
   before do
     @user = User.create(name: "sample", email: "sample@me.com", password: "password", password_confirmation: "password")
   end
-  it "ユーザー名が30文字より多い時バリデーションは通らない" do
-    user = User.create(name: "#{'x' * 31}", email: "test@me.com", password: "password", password_confirmation: "password")
-    expect(user).not_to be_valid
+  
+  describe "ユーザー新規登録" do
+    it "ユーザー名が空欄の時バリデーションは通らない" do
+      user = User.create(name: "", email: "test@me.com", password: "password", password_confirmation: "password")
+      expect(user).not_to be_valid
+    end
+
+    it "ユーザー名が30文字より多い時バリデーションは通らない" do
+      user = User.create(name: "#{'x' * 31}", email: "test@me.com", password: "password", password_confirmation: "password")
+      expect(user).not_to be_valid
+    end
+
+    it "Eメールアドレスが空欄のときバリデーションは通らない" do
+      user = User.create(name: "test", email: "", password: "password", password_confirmation: "password")
+      expect(user).not_to be_valid
+    end
+
+    it "Eメールアドレスが完全なメールアドレスでなければバリデーションは通らない" do
+      user = User.create(name: "test", email: "test@", password: "password", password_confirmation: "password")
+      expect(user).not_to be_valid
+    end
+
+    it "既に使われているEメールアドレスは利用できない" do
+      expect do
+        user = User.create(name: "test", email: "sample@me.com", password: "password", password_confirmation: "password")
+      end.to raise_error( ActiveRecord::RecordNotUnique )
+    end
+
+    it "パスワードが空欄のときバリデーションは通らない" do
+      user = User.create(name: "test", email: "test@me.com", password: "", password_confirmation: "")
+      expect(user).not_to be_valid
+    end
+
+    it "パスワードと確認用パスワードが一致しない場合は登録できない" do
+      user = User.create(name: "test", email: "test@me.com", password: "password", password_confirmation: "passwor")
+      expect(user).not_to be_valid
+    end
   end
 
-  it "Eメールアドレスが完全なメールアドレスでなければバリデーションは通らない" do
-    user = User.create(name: "test", email: "test@", password: "password", password_confirmation: "password")
-    expect(user).not_to be_valid
-  end
+  describe "プロフィール編集" do
+    it "編集時にパスワードの入力なしでも更新ができる" do
+      @user.update(name: "updated_without_password")
+      expect(@user).to be_valid
+    end
 
-  it "既に使われているEメールアドレスは利用できない" do
-    expect do
-      user = User.create(name: "test", email: "sample@me.com", password: "password", password_confirmation: "password")
-    end.to raise_error( ActiveRecord::RecordNotUnique )
+    it "自己紹介文が150文字より多い場合はバリデーションが通らない" do
+      @user.update(bio: "#{'x' * 151}")
+      expect(@user).not_to be_valid
+    end
   end
 
   it "登録するEメールアドレスはすべて小文字に変換される" do
@@ -25,18 +60,7 @@ RSpec.describe User, type: :model do
     expect(user.email).to eq 'test@me.com'
   end
 
-  it "パスワードと確認用パスワードが一致しない場合は登録できない" do
-    user = User.create(name: "test", email: "test@me.com", password: "password", password_confirmation: "passwor")
-    expect(user).not_to be_valid
-  end
-
-  it "編集時にパスワードの入力なしでも更新ができる" do
-    @user.update(name: "updated_without_password")
-    expect(@user).to be_valid
-  end
-
-  it "自己紹介文が150文字より多い場合はバリデーションが通らない" do
-    @user.update(bio: "#{'x' * 151}")
-    expect(@user).not_to be_valid
+  it "パスワードはセキュアに管理されている" do
+    expect(@user.password_digest).not_to eq "password"
   end
 end


### PR DESCRIPTION
#### 既に削除されたブランチで逃していた箇所を修正  
以下のバリデーションが正しく機能することを保証  
  - [x] **ユーザー名:** 空欄または31文字以上の不許可
  - [x]  **Eメールアドレス①:** 不完全なメールアドレスまたは既存のメールアドレスと同一の不許可
  - [x]  **Eメールアドレス②:** 登録時、全ての文字列は小文字に変換される
  - [x] **パスワード①:** 空欄または確認用パスワードとの不一致の不許可
  - [x] **パスワード②:** セキュアにハッシュ化されて管理されている
  - [x] **自己紹介文:** 151文字以上の不許可