### PR TITLE
フォロー機能

### DIFF
--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -4,14 +4,10 @@ class RelationshipsController < ApplicationController
   def create
     @user = User.find(params[:relationship][:followed_id])
     current_user.follow!(@user)
-    current_user.reload
-    @user.reload
   end
 
   def destroy
     @user = Relationship.find(params[:id]).followed
     current_user.unfollow(@user)
-    current_user.reload
-    @user.reload
   end
 end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,2 +1,17 @@
 class RelationshipsController < ApplicationController
+  respond_to? :js
+
+  def create
+    @user = User.find(params[:relationship][:followed_id])
+    current_user.follow!(@user)
+    current_user.reload
+    @user.reload
+  end
+
+  def destroy
+    @user = Relationship.find(params[:id]).followed
+    current_user.unfollow(@user)
+    current_user.reload
+    @user.reload
+  end
 end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,2 @@
+class RelationshipsController < ApplicationController
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,6 +22,7 @@ class UsersController < ApplicationController
   end
 
   def edit
+    not_allow
   end
 
   def update
@@ -56,7 +57,10 @@ class UsersController < ApplicationController
   end
 
   def set_user
-    @user = current_user
+    @user = User.find(params[:id])
   end
 
+  def not_allow
+    redirect_to user_url(current_user.id) unless @user == current_user
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -36,6 +36,12 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
   end
 
+  def following
+  end
+
+  def followers
+  end
+
   def destroy
     @user.destroy
     redirect_to new_user_url, notice: "またね"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   skip_before_action :login_required, only: %i[new create]
-  before_action :set_user, only: %i[edit update destroy]
+  before_action :set_user, only: %i[edit update destroy following followers]
   
   def new
     if logged_in?
@@ -36,15 +36,17 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
   end
 
-  def following
-  end
-
-  def followers
-  end
-
   def destroy
     @user.destroy
     redirect_to new_user_url, notice: "またね"
+  end
+
+  def following
+    @users = @user.following
+  end
+
+  def followers
+    @users = @user.followers
   end
 
   private

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,2 +1,4 @@
 class Relationship < ApplicationRecord
+  belongs_to :followed, class_name: 'User'
+  belongs_to :follower, class_name: 'User'
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,2 @@
+class Relationship < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,8 @@
 class User < ApplicationRecord
   has_many :senryus, dependent: :destroy
   has_many :favorites, dependent: :destroy
-  has_many :active_relationship, foreign_key: 'follower_id', class_name: 'Relationship', dependent: :destroy
-  has_many :passive_relationship, foreign_key: 'followed_id', class_name: 'Relationship', dependent: :destroy
+  has_many :active_relationships, foreign_key: 'follower_id', class_name: 'Relationship', dependent: :destroy
+  has_many :passive_relationships, foreign_key: 'followed_id', class_name: 'Relationship', dependent: :destroy
   has_many :following, through: :active_relationship, source: :followed
   has_many :followers, through: :passive_relationship, source: :follower
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   has_many :senryus, dependent: :destroy
   has_many :favorites, dependent: :destroy
+  has_many :active_relationship, foreign_key: 'follower_id', class_name: 'Relationship', dependent: :destroy
+  has_many :passive_relationship, foreign_key: 'followed_id', class_name: 'Relationship', dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 30 }
   validates :email, presence: true, length: { maximum: 255 }, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,4 +15,16 @@ class User < ApplicationRecord
   validates :bio, length: { maximum: 150 }
 
   mount_uploader :icon, IconUploader
+
+  def follow!(other_user)
+    active_relationships.create!(followed_id: other_user.id)
+  end
+
+  def following?(other_user)
+    active_relationships.find_by(followed_id: other_user.id)
+  end
+
+  def unfollow(other_user)
+    active_relationships.find_by(followed_id: other_user.id).destroy
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :active_relationship, foreign_key: 'follower_id', class_name: 'Relationship', dependent: :destroy
   has_many :passive_relationship, foreign_key: 'followed_id', class_name: 'Relationship', dependent: :destroy
+  has_many :following, through: :active_relationship, source: :followed
+  has_many :followers, through: :passive_relationship, source: :follower
 
   validates :name, presence: true, length: { maximum: 30 }
   validates :email, presence: true, length: { maximum: 255 }, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,8 @@ class User < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :active_relationships, foreign_key: 'follower_id', class_name: 'Relationship', dependent: :destroy
   has_many :passive_relationships, foreign_key: 'followed_id', class_name: 'Relationship', dependent: :destroy
-  has_many :following, through: :active_relationship, source: :followed
-  has_many :followers, through: :passive_relationship, source: :follower
+  has_many :following, through: :active_relationships, source: :followed
+  has_many :followers, through: :passive_relationships, source: :follower
 
   validates :name, presence: true, length: { maximum: 30 }
   validates :email, presence: true, length: { maximum: 255 }, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }

--- a/app/views/relationships/create.js.erb
+++ b/app/views/relationships/create.js.erb
@@ -1,0 +1,1 @@
+$("#follow_form_<%= @user.id %>").html("<%= j(render partial: 'users/follow', locals: { user: @user }) %>");

--- a/app/views/relationships/destroy.js.erb
+++ b/app/views/relationships/destroy.js.erb
@@ -1,0 +1,1 @@
+$("#follow_form_<%= @user.id %>").html("<%= j(render partial: 'users/follow', locals: { user: @user }) %>");

--- a/app/views/users/_follow.html.erb
+++ b/app/views/users/_follow.html.erb
@@ -1,0 +1,12 @@
+<div id="follow_form_<%= user.id %>">
+  <% unless current_user.following?(user) %>
+    <%= form_with(model: current_user.active_relationships.build(followed_id: user.id)) do |f| %>
+      <%= f.hidden_field :followed_id %>
+      <%= f.submit "フォローする" %>
+    <% end %>
+  <% else %>
+    <%= form_with(model: current_user.active_relationships.find_by(followed_id: user.id), method: :delete) do |f| %>
+      <%= f.submit "フォローをやめる" %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/users/followers.html.erb
+++ b/app/views/users/followers.html.erb
@@ -1,0 +1,6 @@
+<h1>フォロワー</h1>
+<ul>
+  <% @users.each do |user| %>
+    <li><%= link_to "#{user.name}", user_path(user.id) %></li>
+  <% end %>
+</ul>

--- a/app/views/users/following.html.erb
+++ b/app/views/users/following.html.erb
@@ -1,0 +1,6 @@
+<h1>フォロー中</h1>
+<ul>
+  <% @users.each do |user| %>
+    <li><%= link_to "#{user.name}", user_path(user.id) %></li>
+  <% end %>
+</ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,6 +3,9 @@
   <%= image_tag(@user.icon.url) if @user.icon && @user.icon.url%><br />
 </div>
 <p><%= @user.bio %></p>
+
+<%= render partial: 'users/follow', locals: { user: @user } %>
+
 <%# のちのち、以下は表示を制限する　とりあえず画面上で操作を行うためのリンク#%>
 <%= link_to 'ログアウト', session_path(@user.id), method: :delete %>
 <%= link_to '投稿', new_senryu_path %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,6 +4,12 @@
 </div>
 <p><%= @user.bio %></p>
 
+<p>フォロー中</p>
+<%= link_to "#{@user.following.size}", following_user_path(@user.id) %>
+
+<p>フォロワー</p>
+<%= link_to "#{@user.followers.size}", followers_user_path(@user.id) %>
+
 <%= render partial: 'users/follow', locals: { user: @user } %>
 
 <%# のちのち、以下は表示を制限する　とりあえず画面上で操作を行うためのリンク#%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   resources :senryus, only: %w(index new create destroy) do
     resources :favorites, only: %w(create destroy)
   end
+  resources :relationships, only: %w(create destroy)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
-  resources :users, only: %w(new create edit update show destroy)
+  resources :users, only: %w(new create edit update show destroy) do
+    member do
+      get :following
+      get :followers
+    end
+  end
   resources :sessions, only: %w(new create destroy)
   resources :senryus, only: %w(index new create destroy) do
     resources :favorites, only: %w(create destroy)

--- a/db/migrate/20190618090354_create_relationships.rb
+++ b/db/migrate/20190618090354_create_relationships.rb
@@ -1,0 +1,13 @@
+class CreateRelationships < ActiveRecord::Migration[5.2]
+  def change
+    create_table :relationships do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+
+      t.timestamps
+    end
+    add_index :relationships, :follower_id
+    add_index :relationships, :followed_id
+    add_index :relationships, [:followed_id, :followed_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_17_081144) do
+ActiveRecord::Schema.define(version: 2019_06_18_090354) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,16 @@ ActiveRecord::Schema.define(version: 2019_06_17_081144) do
     t.datetime "updated_at", null: false
     t.index ["senryu_id"], name: "index_favorites_on_senryu_id"
     t.index ["user_id"], name: "index_favorites_on_user_id"
+  end
+
+  create_table "relationships", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["followed_id"], name: "index_relationships_on_followed_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
   create_table "senryus", force: :cascade do |t|

--- a/spec/factories/relationships.rb
+++ b/spec/factories/relationships.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :relationship do
+    follower_id { 1 }
+    followed_id { 1 }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,4 +5,11 @@ FactoryBot.define do
     password { "password" }
     password_confirmation { "password" }
   end
+
+  factory :user_second, class: User do
+    name { "test_user_02" }
+    email { "test_02@mail.com" }
+    password { "password" }
+    password_confirmation { "password" }
+  end
 end

--- a/spec/features/user.spec.rb
+++ b/spec/features/user.spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.feature User, type: :feature do
   background do
     @test_user_01 = FactoryBot.create(:user)
+    @test_user_02 = FactoryBot.create(:user_second)
   end
 
   def login_as_test_user_01
@@ -71,6 +72,13 @@ RSpec.feature User, type: :feature do
     expect(page).to have_css '.profile-img'
     expect(page).to have_content 'Yohei'
     expect(page).to have_content 'Hello'
+  end
 
+  scenario "他人のプロフィール編集画面にはアクセスできない" do
+    login_as_test_user_01
+
+    visit edit_user_path(@test_user_02.id)
+    
+    expect(current_path).to eq user_path(@test_user_01.id)
   end
 end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Relationship, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,5 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Relationship, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  before do
+    @user1 = FactoryBot.create(:user)
+    @user2 = FactoryBot.create(:user_second)
+    Relationship.create(follower_id: @user1.id, followed_id: @user2.id)
+  end
+
+  it "同じ人をフォローできない(Uniqueインデックスが正しく機能する)" do
+    expect do
+      Relationship.create(follower_id: @user1.id, followed_id: @user2.id)
+    end.to raise_error( ActiveRecord::RecordNotUnique )
+  end
 end


### PR DESCRIPTION
## Relationship
* 以下の関係性を実現するため、relationshipsを中間テーブルとしてusersを二つのテーブルと見立てて多対多アソシエーションを構築
  - ユーザは多数の相手をフォローする
  - ユーザは多数の相手からフォローされる
* relationshipsテーブルの以下二つのカラムは共にuser_idと紐づいている
  - follower_id
  - followed_id 
*  relationshipsテーブルの一レコードの関係性を言語化すると以下のようなイメージ
   - **[follower_id]** と一致したuser_idを持つユーザーがフォローしているユーザーのidが **[followed_id]**
* 同じユーザーをフォローできないよう、follower_idとfollowed_idの組み合わせにユニーク制約を設定
  - これを保証するSpecを追加
* アソシエーションメソッド
  - **active_relationships** => 自分が _フォロワー(誰かをフォローしている)となっている関係_ になっているレコードをrelationshipsから全件取得
  - **passive_relationships** => 自分が _誰かにフォローされている関係_ のレコードをrelationshipsから全件取得
  - **following** => 自分 _が_ フォローしているユーザーの情報を全件取得
  - **followers** => 自分 _を_ フォローしているユーザーの情報を全件取得

## フォローする/フォローをやめるボタン
* ajaxで非同期対応のフォローボタンを、ユーザーページに設置

## フォロー中/フォロワーのユーザー一覧表示機能
* ユーザーページにて、そのユーザーのフォロー中/フォロワーの数と、リンクからそのユーザー一覧を表示

