### PR TITLE
【Fixed】同じ投稿に再びいいね #12

### DIFF
--- a/db/migrate/20190620081450_add_unique_constraint_to_favorites.rb
+++ b/db/migrate/20190620081450_add_unique_constraint_to_favorites.rb
@@ -1,0 +1,5 @@
+class AddUniqueConstraintToFavorites < ActiveRecord::Migration[5.2]
+  def change
+    add_index :favorites, [:user_id, :senryu_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_20_073033) do
+ActiveRecord::Schema.define(version: 2019_06_20_081450) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2019_06_20_073033) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["senryu_id"], name: "index_favorites_on_senryu_id"
+    t.index ["user_id", "senryu_id"], name: "index_favorites_on_user_id_and_senryu_id", unique: true
     t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,5 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe Favorite, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  before do
+    @user1 = FactoryBot.create(:user)
+    @senryu1 = FactoryBot.create(:senryu, user_id: @user1.id)
+    Favorite.create(user_id: @user1.id, senryu_id: @senryu1.id)
+  end
+
+  it "同じ投稿をいいねできない(Uniqueインデックスが正しく機能する)" do
+    expect do
+      Favorite.create(user_id: @user1.id, senryu_id: @senryu1.id)
+    end.to raise_error( ActiveRecord::RecordNotUnique )
+  end
+  
 end


### PR DESCRIPTION
### 同じ投稿にいいねができないようDB側でも設定
* favoritesテーブル、user_idとsenryu_idの組み合わせにユニーク制約を設定
* これを保証するSpecを追加