### PR TITLE
ユーザーネームの文字数指定変更

### DIFF
--- a/app/assets/stylesheets/error_messages.css
+++ b/app/assets/stylesheets/error_messages.css
@@ -21,7 +21,7 @@
 #error_explanation_in_edit_profile {
   font-size: 12px;
   width: 300px;
-  padding: 0 0 0 50px;
+  padding: 0 0 0 30px;
 }
 
 #error_explanation_in_create_new {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   has_many :following, through: :active_relationships, source: :followed
   has_many :followers, through: :passive_relationships, source: :follower
 
-  validates :name, presence: true, length: { maximum: 22 }
+  validates :name, presence: true, length: { maximum: 10 }
   validates :email, presence: true, length: { maximum: 255 }, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
   before_validation { email.downcase! }
   has_secure_password

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -36,12 +36,12 @@
 
   <div class="edit-profile-field">
     <%= f.label :name %>
-    <%= f.text_field :name %>
+    <%= f.text_field :name, placeholder: I18n.t('views.user_name_char_limit') %>
   </div>
 
   <div class="edit-profile-field">
     <%= f.label :bio %>
-    <%= f.text_area :bio %>
+    <%= f.text_area :bio, placeholder: I18n.t('views.user_bio_char_limit') %>
   </div>
 
   <div class="edit-details">
@@ -58,7 +58,7 @@
   
     <div class="edit-profile-field">
       <%= f.label I18n.t('views.new_password') %>
-      <%= f.password_field :password %>
+      <%= f.password_field :password, placeholder: I18n.t('views.minimum_password_length') %>
     </div>
   
     <div class="edit-profile-field">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -23,7 +23,7 @@
   
   <div class="sign-up-field">
     <%= f.label :name %>
-    <%= f.text_field :name ,class: "sign-up-input"%>
+    <%= f.text_field :name ,class: "sign-up-input", placeholder: I18n.t('views.user_name_char_limit')%>
     <div class="underline"></div>
   </div>
 
@@ -35,7 +35,7 @@
 
   <div class="sign-up-field">
     <%= f.label :password %>
-    <%= f.password_field :password ,class: "sign-up-input" %>
+    <%= f.password_field :password ,class: "sign-up-input", placeholder: I18n.t('views.minimum_password_length') %>
     <div class="underline"></div>
   </div>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -38,6 +38,9 @@ ja:
     new_password: "新しいパスワード"
     new_password_confirmation: "新しいパスワードの確認"
     withdraw: "退会する"
+    user_name_char_limit: "10文字以内"
+    user_bio_char_limit: "150文字以内"
+    minimum_password_length: "6文字以上"
   controllers:
     notices:
       login_required: "ログインしてください"

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -11,7 +11,7 @@ ja:
         second_line: "二の句"
         third_line: "三の句"
       user:
-        name: "名前"
+        name: "ユーザーネーム"
         email: "Eメール"
         password: "パスワード"
         password_confirmation: "確認用パスワード"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe User, type: :model do
       expect(user).not_to be_valid
     end
 
-    it "ユーザー名が30文字より多い時バリデーションは通らない" do
-      user = User.create(name: "#{'x' * 31}", email: "test@me.com", password: "password", password_confirmation: "password")
+    it "ユーザー名が10文字より多い時バリデーションは通らない" do
+      user = User.create(name: "#{'x' * 11}", email: "test@me.com", password: "password", password_confirmation: "password")
       expect(user).not_to be_valid
     end
 
@@ -45,7 +45,7 @@ RSpec.describe User, type: :model do
 
   describe "プロフィール編集" do
     it "編集時にパスワードの入力なしでも更新ができる" do
-      @user.update(name: "updated_without_password")
+      @user.update(name: "no_pass")
       expect(@user).to be_valid
     end
 


### PR DESCRIPTION
### 表示の都合により、ユーザー名を10文字以内とする  
* それにともないモデルのテストの修正→正常
* プレースホルダーの追加